### PR TITLE
Fix test failure when running locally in non-UTC system

### DIFF
--- a/src/generator/generate.test.ts
+++ b/src/generator/generate.test.ts
@@ -294,7 +294,7 @@ describe("generate table types", () => {
 describe("generateDatabaseTypes", () => {
     beforeEach(() => {
         vi.useFakeTimers();
-        vi.setSystemTime(new Date(2025, 0, 1));
+        vi.setSystemTime(new Date(Date.UTC(2025, 0, 1)));
     });
     afterEach(() => {
         vi.useRealTimers();


### PR DESCRIPTION
When running locally, the test `should generate database types for single table` fails when the system time is not UTC:

```
- // Timestamp: 2025-01-01T00:00:00.000Z
+ // Timestamp: 2025-01-01T05:00:00.000Z
```

I believe the call to `vi.setSystemTime(new Date(2025, 0, 1));` should specify UTC.