### PR TITLE
fix: point exports.import.types to actual .d.ts file

### DIFF
--- a/.changeset/bright-chairs-develop.md
+++ b/.changeset/bright-chairs-develop.md
@@ -1,0 +1,5 @@
+---
+"kysely-oracledb": patch
+---
+
+fixed package json exports

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "exports": {
         ".": {
             "import": {
-                "types": "./dist/index.d.mts",
+                "types": "./dist/index.d.ts",
                 "default": "./dist/esm/index.js"
             },
             "require": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "author": "Griffiths Waite",
     "license": "MIT",
     "main": "dist/index.js",
-    "module": "dist/index.mjs",
+    "module": "dist/esm/index.js",
     "types": "dist/index.d.ts",
     "type": "module",
     "exports": {
@@ -15,7 +15,7 @@
                 "default": "./dist/esm/index.js"
             },
             "require": {
-                "types": "./dist/index.d.ts",
+                "types": "./dist/index.d.cts",
                 "default": "./dist/index.js"
             },
             "default": "./dist/index.js"


### PR DESCRIPTION
Right now our `package.json` declares:

```jsonc
"exports": {
  ".": {
    "import": {
      "types": "./dist/index.d.mts",   // ← this file doesn’t exist
      "default": "./dist/esm/index.js"
    },
  }
}
```

but our build only emits:

```
dist/
├── esm/
│   ├── index.js
│   └── index.js.map
├── index.d.cts
├── index.d.ts
├── index.js
└── index.js.map
```

As a result:

* **Deno** (and other ESM loaders that respect `exports.import.types`) fail with
  `TS2307: Cannot find module 'kysely-oracledb'`.
* VSCode’s TS server still “works” because it falls back to the top-level `"types": "dist/index.d.ts"` field.

This PR updates the `exports.import.types` entry to point at the real file, so that Deno, Node-style ESM resolution, and downstream tools can correctly locate our type definitions.

**Why This Matters**

* **Deno compatibility**: fixes `deno check` errors without any local hacks.
* **ESM loaders**: any loader which honors `package.json > exports` will find the right `.d.ts`.
* **Zero breaking changes**: consumers who already use the root `"types"` or `require` path are unaffected.